### PR TITLE
enable_additional_args

### DIFF
--- a/helm/polymesh/templates/statefulset.yaml
+++ b/helm/polymesh/templates/statefulset.yaml
@@ -91,6 +91,9 @@ spec:
             - --node-key-file
             -   /nodeKey/{{ .Values.nodeKey.filename }}
             {{- end }}
+            {{- range .Values.polymesh.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           env:
             {{- toYaml .Values.polymesh.extraEnv | nindent 12 }}
           ports:

--- a/helm/polymesh/values.yaml
+++ b/helm/polymesh/values.yaml
@@ -27,6 +27,7 @@ polymesh:
     -   '"4096"'
     - --pruning
     -   archive
+  additionalArgs: []
   extraEnv: []
 
 operatorKeys: {}


### PR DESCRIPTION
Enable appending additional args to the polymesh command without resetting the default args.