### PR TITLE
Add Prometheus Operator ServiceMonitor template to Helm chart

### DIFF
--- a/helm/polymesh/templates/servicemonitor.yaml
+++ b/helm/polymesh/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.service.prometheus.servicemonitor }}
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "polymesh.fullname" . }}
+  labels:
+    {{- include "polymesh.labels" . | nindent 4 }}
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: polymesh
+  endpoints:
+  - path: /metrics
+    port: prometheus
+  namespaceSelector:
+    any: true
+
+{{- end }}

--- a/helm/polymesh/values.yaml
+++ b/helm/polymesh/values.yaml
@@ -80,6 +80,7 @@ service:
     enabled: true
     type: ClusterIP
     port: 9615
+    servicemonitor: true
   jsonrpc:
     enabled: false
     type: ClusterIP


### PR DESCRIPTION
Prometheus Operator is a common configuration stack used to monitor services inside a cluster - https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack

It comes with an Operator that continuously monitors K8s API for `ServiceMonitor` objects and dynamically reconfigures Prometheus as these get created to match specified `Service`s.

This adds an option to create `ServiceMonitor` object to automatically start scraping any Polymesh services Prometheus endpoints. 

Depends on #17 