### PR TITLE
Correctly match labels for ServiceMonitor

### DIFF
--- a/helm/polymesh/templates/servicemonitor.yaml
+++ b/helm/polymesh/templates/servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: polymesh
+      {{- include "polymesh.selectorLabels" . | nindent 6 }}
   endpoints:
   - path: /metrics
     port: prometheus


### PR DESCRIPTION
Use helper `selectorLabels` to distinguish between helm deploys.

Otherwise if two (or more) Polymesh releases deployed, each `ServiceMonitor` will match all the deployments, wrongly multiplying monitoring jobs in Prometheus.

So this helper label template will add `app.kubernetes.io/instance: <helm release name here>` label and each `ServiceMonitor` will only match its own release.