### PR TITLE
Fix db location for keys

### DIFF
--- a/helm/polymesh/templates/statefulset.yaml
+++ b/helm/polymesh/templates/statefulset.yaml
@@ -135,9 +135,9 @@ spec:
             {{- if .Values.operatorKeys.requireSecret }}
             {{- if has "--operator" .Values.polymesh.args }}
             - name: operator-keys-ephemeral
-              mountPath: /var/lib/polymesh/chains/polymesh_mainnet/keystore
+              mountPath: /var/lib/polymesh/chains/mainnet/keystore
             - name: operator-keys-ephemeral
-              mountPath: /var/lib/polymesh/chains/polymesh_testnet/keystore
+              mountPath: /var/lib/polymesh/chains/testnet/keystore
             {{- end }}
             {{- if .Values.nodeKey.existingSecret }}
             - name: node-key


### PR DESCRIPTION
The location for DB keys is wrong as you can see from the operator log:
```
2021-11-10 13:25:33 🏷 Node name: millino-operator    
2021-11-10 13:25:33 👤 Role: AUTHORITY    
2021-11-10 13:25:33 💾 Database: RocksDb at /var/lib/polymesh/chains/mainnet/db 
```
The current chart is storing the keys at `polymesh_mainnet` and this is causing staking issues.

Fixed with expected locations.